### PR TITLE
Install python requirement for the base image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,15 @@ RUN apt-get update && \
     apt-get install -y python3 python3-pip && \
     apt-get clean
 
+# Copy requirement and do the installation
+COPY requirements.txt /tmp
+
+# Install the required Python packages
+RUN pip3 install --no-cache-dir -r /tmp/requirements.txt
+
+# Remove the file
+RUN rm -rf  /tmp/requirements.txt
+
 #********************Setup an develop environment for building.
 # If this scale up, we will switch to dual images
 FROM ${base_image} as build_image_develop
@@ -42,9 +51,6 @@ WORKDIR /app
 
 # Copy the requirements.txt file
 COPY ${package_location}/ /app/
-
-# Install the required Python packages
-RUN pip3 install --no-cache-dir -r requirements.txt
 
 # Expose the port that the Flask app runs on
 EXPOSE 5000

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -27,7 +27,7 @@ mkdir ${package_location} && \
 cd ${package_location} && \
 cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=./redist/libs/quottery_cpp && \
 make install"
-install_cmd="cp -r ${DOCKER_SRC_DIR}/quottery_cpp_wrapper.py ${DOCKER_SRC_DIR}/app.py ${DOCKER_SRC_DIR}/requirements.txt ${DOCKER_SRC_DIR}/${package_location}/redist"
+install_cmd="cp -r ${DOCKER_SRC_DIR}/quottery_cpp_wrapper.py ${DOCKER_SRC_DIR}/app.py ${DOCKER_SRC_DIR}/${package_location}/redist"
 docker run --rm -v ./:${DOCKER_SRC_DIR} -u $(id -u) ${DEV_IMAGE} bash -c "cd /app_code && $build_cmd && $install_cmd"
 
 # Package into a new release image base on runtime time


### PR DESCRIPTION
This will help install the python requirements at the base image, avoid installation at compilation/packaging step.

cc: @icyblob 