### PR TITLE
Branching more cases for get_active_bets API

### DIFF
--- a/app.py
+++ b/app.py
@@ -97,10 +97,14 @@ def filter_locked_bets(bets_list):
 
 
 def filter_inactive_bets(bets_list):
+    # Inactive bet is a bet that has result
+    filtered_bets = bets_list
+    filtered_bets = list(filter(lambda p: p['result'] >= 0, filtered_bets))
+
     # Check the end date and close time
     current_utc_date = datetime.now(timezone.utc)
     inactive_bets = []
-    for bet in bets_list:
+    for bet in filtered_bets:
         inactive_flag = False
         end_datetime_str = bet['end_date'] + ' ' + bet['end_time']
 

--- a/app.py
+++ b/app.py
@@ -59,7 +59,7 @@ def filter_active_bets(bets_list):
     current_utc_date = datetime.now(timezone.utc)
     active_bets = []
     for bet in filtered_bets:
-        active_flag = True
+        active_flag = False
         # Combine the date and time strings and parse them into a datetime object
         closed_datetime_str = bet['close_date'] + ' ' + bet['close_time']
         try:
@@ -79,7 +79,7 @@ def filter_locked_bets(bets_list):
     current_utc_date = datetime.now(timezone.utc)
     locked_bets = []
     for bet in bets_list:
-        locked_flag = True
+        locked_flag = False
         closed_datetime_str = bet['close_date'] + ' ' + bet['close_time']
         end_datetime_str = bet['end_date'] + ' ' + bet['end_time']
 
@@ -101,7 +101,7 @@ def filter_inactive_bets(bets_list):
     current_utc_date = datetime.now(timezone.utc)
     inactive_bets = []
     for bet in bets_list:
-        inactive_flag = True
+        inactive_flag = False
         end_datetime_str = bet['end_date'] + ' ' + bet['end_time']
 
         try:

--- a/db_updater.py
+++ b/db_updater.py
@@ -123,7 +123,7 @@ def update_db_unversion():
     CREATE TABLE IF NOT EXISTS version (
             version_info TEXT PRIMARY KEY)''')
 
-    # Insert or update the version information# 
+    # Insert or update the version information#
     cursor.execute('''
     INSERT INTO version (version_info) VALUES (?);
     ''', (update_version,))
@@ -137,7 +137,7 @@ def update_db_unversion():
 
     conn.commit()
     conn.close()
-    
+
 # Function that check if we need to convert the old version to new version of table
 # Only have ability update version gradually. Can not jump from a very old version
 def update_db():
@@ -160,13 +160,13 @@ def update_db():
         if field_exists:
             cursor.execute('SELECT version_info FROM version;')
             # Fetch the result
-            version_info = cursor.fetchone()[0]    
+            version_info = cursor.fetchone()[0]
             if parse_version(DB_VERSION) == parse_version(version_info):
                 need_update = False
             else:
                 need_update = True
         else:
-            need_update = True 
+            need_update = True
     conn.close()
 
     # Unversion bump to 1.0
@@ -176,7 +176,7 @@ def update_db():
         # Update from unversion to 1.0
         if not field_exists:
             logger.info(f"Updating from unversion db to 1.0 ...")
-            
+
             # Back up the database file
             timestamp = datetime.now().strftime('%Y%m%d%H%M%S')
             # New file name with the timestamp
@@ -190,7 +190,7 @@ def update_db():
             sys.exit(1)
 
         # Update from other version happend sequential here if neccessary
-        
+
         logger.info(f"Update db version successfully. Current version {DB_VERSION}")
     else:
         logger.info(f"Version is matched. Skip the update.")
@@ -213,7 +213,7 @@ def get_qtry_basic_info_from_node():
         logger.warning(f"Error get active basic info of qtry from node: {e}")
         return 1, {}
 
-def fetch_active_bets_from_node():
+def fetch_bets_from_node():
     # Connect to the node and get current active bets
     try:
         sts, active_bets = qt.get_active_bets()
@@ -297,14 +297,14 @@ def update_betting_odds(conn, bet_id):
         cur.execute("UPDATE quottery_info SET betting_odds = ? WHERE bet_id = ?", (betting_odds_str, bet_id))
 
 
-def update_database_with_active_bets():
+def update_database_with_bets():
     while True:
         try:
-            sts, active_bets = fetch_active_bets_from_node()
+            sts, active_bets = fetch_bets_from_node()
 
-            # Verify the active_bets
+            # Verify the bets
             if not active_bets:
-                logger.warning('[WARNING] Active bets from node is empty! Display the local database')
+                logger.warning('[WARNING] Bets from node is empty! Using the local database')
 
             sts, qt_basic_info = get_qtry_basic_info_from_node()
             if not qt_basic_info:
@@ -495,4 +495,4 @@ if __name__ == '__main__':
     qt = quottery_cpp_wrapper.QuotteryCppWrapper(QUOTTERY_LIBS, NODE_IP, NODE_PORT, 'DB_UPDATER')
 
     init_db()
-    update_database_with_active_bets()
+    update_database_with_bets()


### PR DESCRIPTION
Separate active bet, locked bet, and inactive bet API. The old get_active_bet now becomes get_all_bets.
This PR currently uses close/end date and time for checking. For active bet, we also use the `result` field in database for double-check.

cc: @icyblob 