### PR TITLE
Add get_[active|locked|inactive|all]_bets and pagination filtering

### DIFF
--- a/app.py
+++ b/app.py
@@ -101,7 +101,6 @@ def apply_pagination(bets_list):
         paginated_bets = pagination_page(filtered_bets, page, page_size)
         ret = {
             'bet_list': paginated_bets,
-            'paginations': PAGINATIONS_FILTER,
             'page': {
                 "current_records" : len(paginated_bets),
                 "total_records": total_records,
@@ -113,7 +112,6 @@ def apply_pagination(bets_list):
     else:
         ret = {
             'bet_list': filtered_bets,
-            'paginations': PAGINATIONS_FILTER,
             'page': {
                 "current_records" : len(filtered_bets),
                 "total_records": len(filtered_bets),
@@ -280,6 +278,14 @@ def get_inactive_bets():
     # Reply with json
     return jsonify(ret)
 
+@app.route('/get_available_filters', methods=['GET'])
+def get_filter():
+
+    # Add the node info
+    ret = {'available_filters': PAGINATIONS_FILTER}
+
+    # Reply with json
+    return jsonify(ret)
 
 if __name__ == '__main__':
     # Init parameters with environment variables

--- a/app.py
+++ b/app.py
@@ -25,18 +25,38 @@ PAGINATION_THRESHOLD = 100
 
 PAGINATIONS_FILTER = [
     "bet_id",
+    "open_date",
+    "open_time",
     "close_date",
-    "creator",
+    "close_time",
     "end_date",
+    "end_time",
+    "creator",
     "max_slot_per_option",
+    "amount_per_bet_slot",
     "no_ops",
     "no_options",
-    "open_date",
     "option_desc",
     "result",
     "status",
     "oracle_id",
-    "bet_desc"
+    "bet_desc",
+    "oracle_vote"
+]
+
+# This filter apply for containing check
+CONTAINING_FILTER = [
+    "open_date",
+    "open_time",
+    "close_date",
+    "close_time",
+    "end_date",
+    "end_time",
+    "creator",
+    "option_desc",
+    "oracle_id",
+    "bet_desc",
+    "oracle_vote"
 ]
 
 
@@ -47,7 +67,7 @@ def pagination_filter(bets_list):
         pagin_filter = request.args.get(pagin)
         if pagin_filter:
             # This only checks for containing
-            if pagin == 'bet_desc' or pagin == 'oracle_id':
+            if pagin in CONTAINING_FILTER:
                 filtered_bets = list(filter(lambda p: pagin_filter in p[pagin], filtered_bets))
             else:  # Check for match all
                 filtered_bets = list(filter(lambda p: str(p[pagin]) == pagin_filter, filtered_bets))

--- a/app.py
+++ b/app.py
@@ -97,10 +97,14 @@ def filter_locked_bets(bets_list):
 
 
 def filter_inactive_bets(bets_list):
+    # Inactive bet is a bet that has result
+    filtered_bets = bets_list
+    filtered_bets = list(filter(lambda p: p['result'] >= 0, filtered_bets))
+
     # Check the end date and close time
     current_utc_date = datetime.now(timezone.utc)
     inactive_bets = []
-    for bet in bets_list:
+    for bet in filtered_bets:
         inactive_flag = False
         end_datetime_str = bet['end_date'] + ' ' + bet['end_time']
 

--- a/app.py
+++ b/app.py
@@ -50,7 +50,7 @@ def pagination_filter(bets_list):
             if pagin == 'bet_desc' or pagin == 'oracle_id':
                 filtered_bets = list(filter(lambda p: pagin_filter in p[pagin], filtered_bets))
             else:  # Check for match all
-                filtered_bets = list(filter(lambda p: p[pagin] == pagin_filter, filtered_bets))
+                filtered_bets = list(filter(lambda p: str(p[pagin]) == pagin_filter, filtered_bets))
 
     return filtered_bets
 

--- a/app.py
+++ b/app.py
@@ -59,7 +59,7 @@ def filter_active_bets(bets_list):
     current_utc_date = datetime.now(timezone.utc)
     active_bets = []
     for bet in filtered_bets:
-        active_flag = True
+        active_flag = False
         # Combine the date and time strings and parse them into a datetime object
         closed_datetime_str = bet['close_date'] + ' ' + bet['close_time']
         try:
@@ -79,7 +79,7 @@ def filter_locked_bets(bets_list):
     current_utc_date = datetime.now(timezone.utc)
     locked_bets = []
     for bet in bets_list:
-        locked_flag = True
+        locked_flag = False
         closed_datetime_str = bet['close_date'] + ' ' + bet['close_time']
         end_datetime_str = bet['end_date'] + ' ' + bet['end_time']
 
@@ -101,7 +101,7 @@ def filter_inactive_bets(bets_list):
     current_utc_date = datetime.now(timezone.utc)
     inactive_bets = []
     for bet in bets_list:
-        inactive_flag = True
+        inactive_flag = False
         end_datetime_str = bet['end_date'] + ' ' + bet['end_time']
 
         try:

--- a/app.py
+++ b/app.py
@@ -21,7 +21,7 @@ NODE_IP = None
 NODE_PORT = None
 DATABASE_PATH = "."
 DATABASE_FILE = 'database.db'
-PAGINATION_THRESHOLD = 10
+PAGINATION_THRESHOLD = 100
 
 PAGINATIONS_FILTER = [
     "bet_id",
@@ -61,7 +61,7 @@ def filter_pagination(bets_list, page, page_size):
 
 def get_bets_base():
     if not os.path.isfile(DATABASE_FILE):
-        logger.warning(f"No database found {DATABASE_FILE}. Please wait...")
+        logger.warning(f"No database found at {DATABASE_FILE}. Please wait...")
         return jsonify({'bet_list': [], 'node_info': []})
 
     conn = sqlite3.connect(DATABASE_FILE)
@@ -160,9 +160,10 @@ def get_all_bets():
 
     # Get pagination parameters
     page = int(request.args.get('page', 1))
-    page_size = int(request.args.get('page_size', 10))
+    page_size = int(request.args.get('page_size', PAGINATION_THRESHOLD))
 
     if len(bets_list) > PAGINATION_THRESHOLD:
+        print('a')
         filtered_bets, total_records = filter_pagination(bets_list, page, page_size)
         ret = {
             'bet_list': filtered_bets,
@@ -176,6 +177,7 @@ def get_all_bets():
             }
         }
     else:
+        print('b')
         ret = {
             'bet_list': bets_list,
             'node_info': node_info,
@@ -198,7 +200,7 @@ def get_active_bets():
 
     # Get pagination parameters
     page = int(request.args.get('page', 1))
-    page_size = int(request.args.get('page_size', 10))
+    page_size = int(request.args.get('page_size', PAGINATION_THRESHOLD))
 
     active_bets = filter_active_bets(bets_list=bets_list)
 
@@ -236,7 +238,7 @@ def get_locked_bets():
 
     # Get pagination parameters
     page = int(request.args.get('page', 1))
-    page_size = int(request.args.get('page_size', 10))
+    page_size = int(request.args.get('page_size', PAGINATION_THRESHOLD))
 
     locked_bets = filter_locked_bets(bets_list=bets_list)
 
@@ -274,7 +276,7 @@ def get_inactive_bets():
 
     # Get pagination parameters
     page = int(request.args.get('page', 1))
-    page_size = int(request.args.get('page_size', 10))
+    page_size = int(request.args.get('page_size', PAGINATION_THRESHOLD))
 
     inactive_bets = filter_inactive_bets(bets_list=bets_list)
 

--- a/app.py
+++ b/app.py
@@ -133,12 +133,12 @@ def filter_locked_bets(bets_list):
 
 def filter_inactive_bets(bets_list):
     # Inactive bet is a bet that has result
-    filtered_bets = list(filter(lambda p: p['result'] >= 0, bets_list))
+    inactive_bets_results = list(filter(lambda p: p['result'] >= 0, bets_list))
 
     # Check the end date and close time
     current_utc_date = datetime.now(timezone.utc)
-    inactive_bets = []
-    for bet in filtered_bets:
+    inactive_bets_datetime = []
+    for bet in bets_list:
         inactive_flag = False
         end_datetime_str = bet['end_date'] + ' ' + bet['end_time']
 
@@ -149,9 +149,9 @@ def filter_inactive_bets(bets_list):
             logger.warning(f"Date time format is not correct. Will not use for filtering active/inactive: {e}")
 
         if inactive_flag:
-            inactive_bets.append(bet)
+            inactive_bets_datetime.append(bet)
 
-    return inactive_bets
+    return inactive_bets_datetime + inactive_bets_results
 
 
 @app.route('/get_all_bets', methods=['GET'])

--- a/db_updater.py
+++ b/db_updater.py
@@ -123,7 +123,7 @@ def update_db_unversion():
     CREATE TABLE IF NOT EXISTS version (
             version_info TEXT PRIMARY KEY)''')
 
-    # Insert or update the version information# 
+    # Insert or update the version information#
     cursor.execute('''
     INSERT INTO version (version_info) VALUES (?);
     ''', (update_version,))
@@ -137,7 +137,7 @@ def update_db_unversion():
 
     conn.commit()
     conn.close()
-    
+
 # Function that check if we need to convert the old version to new version of table
 # Only have ability update version gradually. Can not jump from a very old version
 def update_db():
@@ -160,13 +160,13 @@ def update_db():
         if field_exists:
             cursor.execute('SELECT version_info FROM version;')
             # Fetch the result
-            version_info = cursor.fetchone()[0]    
+            version_info = cursor.fetchone()[0]
             if parse_version(DB_VERSION) == parse_version(version_info):
                 need_update = False
             else:
                 need_update = True
         else:
-            need_update = True 
+            need_update = True
     conn.close()
 
     # Unversion bump to 1.0
@@ -176,7 +176,7 @@ def update_db():
         # Update from unversion to 1.0
         if not field_exists:
             logger.info(f"Updating from unversion db to 1.0 ...")
-            
+
             # Back up the database file
             timestamp = datetime.now().strftime('%Y%m%d%H%M%S')
             # New file name with the timestamp
@@ -190,7 +190,7 @@ def update_db():
             sys.exit(1)
 
         # Update from other version happend sequential here if neccessary
-        
+
         logger.info(f"Update db version successfully. Current version {DB_VERSION}")
     else:
         logger.info(f"Version is matched. Skip the update.")
@@ -213,7 +213,7 @@ def get_qtry_basic_info_from_node():
         logger.warning(f"Error get active basic info of qtry from node: {e}")
         return 1, {}
 
-def fetch_active_bets_from_node():
+def fetch_bets_from_node():
     # Connect to the node and get current active bets
     try:
         sts, active_bets = qt.get_active_bets()
@@ -297,14 +297,14 @@ def update_betting_odds(conn, bet_id):
         cur.execute("UPDATE quottery_info SET betting_odds = ? WHERE bet_id = ?", (betting_odds_str, bet_id))
 
 
-def update_database_with_active_bets():
+def update_database_with_bets():
     while True:
         try:
-            sts, active_bets = fetch_active_bets_from_node()
+            sts, active_bets = fetch_bets_from_node()
 
-            # Verify the active_bets
+            # Verify the bets
             if not active_bets:
-                logger.warning('[WARNING] Active bets from node is empty! Display the local database')
+                logger.warning('[WARNING] Bets from node is empty! Using the local database')
 
             sts, qt_basic_info = get_qtry_basic_info_from_node()
             if not qt_basic_info:
@@ -495,4 +495,4 @@ if __name__ == '__main__':
     qt = quottery_cpp_wrapper.QuotteryCppWrapper(QUOTTERY_LIBS, NODE_IP, NODE_PORT, 'DB_UPDATER')
 
     init_db()
-    update_database_with_active_bets()
+    update_database_with_bets()


### PR DESCRIPTION
//cc: @cyber-pc 

This PR split the old get_active_bets to:
- get_active_bets: only get active bets, which has not yet reached close date, able to join bets.
- get_locked_bets: only get locked bets, which has reached close date but not yet end date, unable to join bets, but not yet has results.
- get_inactive_bets: only get inactive bets, which either has reached end date, or already has results

Add pagination to the request:
- Automatically split the result to pages if the total records exceed the PAGINATION_THRESHOLD
- Add filtering to the return bet list with a list of filtering:
```python3
PAGINATIONS_FILTER = [
    "bet_id",
    "open_date",
    "open_time",
    "close_date",
    "close_time",
    "end_date",
    "end_time",
    "creator",
    "max_slot_per_option",
    "amount_per_bet_slot",
    "no_ops",
    "no_options",
    "option_desc",
    "result",
    "status",
    "oracle_id",
    "bet_desc",
    "oracle_vote"
]
```