### PR TITLE
Add http endpoint for qtry wrapper.

### DIFF
--- a/build_docker.sh
+++ b/build_docker.sh
@@ -27,7 +27,7 @@ mkdir ${package_location} && \
 cd ${package_location} && \
 cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=./redist/libs/quottery_cpp && \
 make install"
-install_cmd="cp -r ${DOCKER_SRC_DIR}/quottery_cpp_wrapper.py ${DOCKER_SRC_DIR}/db_updater.py ${DOCKER_SRC_DIR}/app.py ${DOCKER_SRC_DIR}/${package_location}/redist"
+install_cmd="cp -r ${DOCKER_SRC_DIR}/quottery_rpc_wrapper.py ${DOCKER_SRC_DIR}/qtry_utils.py ${DOCKER_SRC_DIR}/db_updater.py ${DOCKER_SRC_DIR}/app.py ${DOCKER_SRC_DIR}/${package_location}/redist"
 docker run --rm -v ./:${DOCKER_SRC_DIR} -u $(id -u) ${DEV_IMAGE} bash -c "cd /app_code && $build_cmd && $install_cmd"
 
 # Package into a new release image base on runtime time

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,15 +3,14 @@ x-common-env: &common-env DATABASE_PATH=/database
 services:
   db-updater:
     # Change the path to suitable Docker image
-    image: "ghcr.io/icyblob/flask-app:2.2"
+    image: "ghcr.io/icyblob/flask-app:latest"
     volumes:
         # Mount the current folder as folder for saving database. Make sure you mount the same folder with flask-app
       - .:/database
       - /etc/localtime:/etc/localtime:ro
       - /etc/timezone:/etc/timezone:ro
     environment:
-      - NODE_IP=5.199.134.150         # example node IP. Replace with the real IP
-      - NODE_PORT=31844               # example node port. Replace with the real port
+      - NODE_IP=https://rpc.qubic.org        # example endpoint. Replace with the real endpoint
       - *common-env
     command: ["python3", "db_updater.py"]
     restart: always
@@ -19,7 +18,7 @@ services:
     depends_on:
       - db-updater
     # Change the path to suitable Docker image
-    image: "ghcr.io/icyblob/flask-app:2.2"
+    image: "ghcr.io/icyblob/flask-app:latest"
     ports:
       - 5000:5000
     volumes:

--- a/qtry_utils.py
+++ b/qtry_utils.py
@@ -1,0 +1,123 @@
+import ctypes
+
+class QtryBasicInfoOutput(ctypes.Structure):
+    """Wrapper struct for accessing QtryBasicInfoOutput in quottery_cpp library"""
+    _fields_ = [
+    ('feePerSlotPerHour', ctypes.c_uint64),  # Amount of qus
+    ('gameOperatorFee', ctypes.c_uint64),  # 4 digit number ABCD means AB.CD% | 1234 is 12.34%
+    ('shareholderFee', ctypes.c_uint64),   # 4 digit number ABCD means AB.CD% | 1234 is 12.34%
+    ('minBetSlotAmount', ctypes.c_uint64), # amount of qus
+    ('burnFee', ctypes.c_uint64),          # percentage
+    ('nIssuedBet', ctypes.c_uint64),       # number of issued bet
+    ('moneyFlow', ctypes.c_uint64),
+    ('moneyFlowThroughIssueBet', ctypes.c_uint64),
+    ('moneyFlowThroughJoinBet', ctypes.c_uint64),
+    ('moneyFlowThroughFinalizeBet', ctypes.c_uint64),
+    ('earnedAmountForShareHolder', ctypes.c_uint64),
+    ('paidAmountForShareHolder', ctypes.c_uint64),
+    ('earnedAmountForBetWinner', ctypes.c_uint64),
+    ('distributedAmount', ctypes.c_uint64),
+    ('burnedAmount', ctypes.c_uint64),
+    ('gameOperator', ctypes.c_uint8 * 32)
+    ]
+
+
+class QuotteryFeesOutput(ctypes.Structure):
+    """Wrapper struct for accessing QuotteryFeesOutput in quottery_cpp library"""
+    _fields_ = [
+        ('feePerSlotPerDay', ctypes.c_uint64),  # Amount of qus
+        ('gameOperatorFee', ctypes.c_uint64),  # Amount of qus
+        # 4 digit number ABCD means AB.CD% | 1234 is 12.34%
+        ('shareholderFee', ctypes.c_uint64),
+        # 4 digit number ABCD means AB.CD% | 1234 is 12.34%
+        ('minBetSlotAmount', ctypes.c_uint64),
+        ('gameOperatorPubkey', ctypes.c_uint8 * 32)
+    ]
+
+class BetInfoOutput(ctypes.Structure):
+    """Wrapper struct for accessing BetInfoOutput in quottery_cpp library"""
+    _fields_ = [
+        ('betId', ctypes.c_uint32),
+        ('nOption', ctypes.c_uint32),  # options number
+        ('creator', ctypes.c_uint8 * 32),
+        ('betDesc', ctypes.c_uint8 * 32),
+        ('optionDesc', ctypes.c_uint8 * 256),  # 8x(32)=256bytes
+        ('oracleProviderId', ctypes.c_uint8 * 256),  # 256x8=2048bytes ???
+        ('oracleFees', ctypes.c_uint32 * 8),   # 4x8 = 32 bytes
+
+        # Packed time relate to the bet. The format is [YY, MM, DD, HH, MM, SS]
+        ('openDateTime', ctypes.c_uint32),
+        ('closeDateTime', ctypes.c_uint32),   # stop receiving bet date
+        ('endDateTime', ctypes.c_uint32),       # result date
+
+        #     // Amounts and numbers
+        ('minBetAmount', ctypes.c_uint64),
+        ('maxBetSlotPerOption', ctypes.c_uint32),
+        # how many bet slots have been filled on each option
+        ('currentBetState', ctypes.c_uint32 * 8),
+
+        # Voting result
+        ## Vote of each oracle provider chose
+        ## -1 mean invalid
+        ('betResultWonOption', ctypes.c_int8 * 8),
+        ## List of oracle providers that attend to the voting
+        ## -1 mean in valid
+        ('betResultOPId', ctypes.c_int8 * 8)
+    ]
+
+class QtryBasicInfoOutput(ctypes.Structure):
+    """Wrapper struct for accessing QtryBasicInfoOutput in quottery_cpp library"""
+    _fields_ = [
+    ('feePerSlotPerHour', ctypes.c_uint64),  # Amount of qus
+    ('gameOperatorFee', ctypes.c_uint64),  # 4 digit number ABCD means AB.CD% | 1234 is 12.34%
+    ('shareholderFee', ctypes.c_uint64),   # 4 digit number ABCD means AB.CD% | 1234 is 12.34%
+    ('minBetSlotAmount', ctypes.c_uint64), # amount of qus
+    ('burnFee', ctypes.c_uint64),          # percentage
+    ('nIssuedBet', ctypes.c_uint64),       # number of issued bet
+    ('moneyFlow', ctypes.c_uint64),
+    ('moneyFlowThroughIssueBet', ctypes.c_uint64),
+    ('moneyFlowThroughJoinBet', ctypes.c_uint64),
+    ('moneyFlowThroughFinalizeBet', ctypes.c_uint64),
+    ('earnedAmountForShareHolder', ctypes.c_uint64),
+    ('paidAmountForShareHolder', ctypes.c_uint64),
+    ('earnedAmountForBetWinner', ctypes.c_uint64),
+    ('distributedAmount', ctypes.c_uint64),
+    ('burnedAmount', ctypes.c_uint64),
+    ('gameOperator', ctypes.c_uint8 * 32)
+    ]
+
+class QtryBetOptionDetail(ctypes.Structure):
+    """Wrapper struct for accessing QtryBetOptionDetail in quottery_cpp library"""
+    _fields_ = [
+        ('bettor', ctypes.c_uint8 * 32 * 1024)
+    ]
+
+def QTRY_GET_YEAR(data):
+    return (data >> 26) + 24
+
+def QTRY_GET_MONTH(data):
+    return (data >> 22) & 0b1111
+
+def QTRY_GET_DAY(data):
+    return (data >> 17) & 0b11111
+
+def QTRY_GET_HOUR(data):
+    return (data >> 12) & 0b11111
+
+def QTRY_GET_MINUTE(data):
+    return (data >> 6) & 0b111111
+
+def QTRY_GET_SECOND(data):
+    return data & 0b111111
+
+# Unpack date to [YY, MM, DD, HH, MM, SS] from a uin32_t
+def unpack_date(data):
+    YY_MM_DD_HH_MM_SS = [0] * 6
+    YY_MM_DD_HH_MM_SS[0] = QTRY_GET_YEAR(data)
+    YY_MM_DD_HH_MM_SS[1] = QTRY_GET_MONTH(data)
+    YY_MM_DD_HH_MM_SS[2] = QTRY_GET_DAY(data)
+    YY_MM_DD_HH_MM_SS[3] = QTRY_GET_HOUR(data)
+    YY_MM_DD_HH_MM_SS[4] = QTRY_GET_MINUTE(data)
+    YY_MM_DD_HH_MM_SS[5] = QTRY_GET_SECOND(data)
+
+    return YY_MM_DD_HH_MM_SS

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ MarkupSafe==2.1.5
 packaging==24.1
 pycparser==2.22
 Werkzeug==3.0.3
+requests==2.25.1

--- a/test_qtry.py
+++ b/test_qtry.py
@@ -1,0 +1,39 @@
+import unittest
+import quottery_rpc_wrapper
+
+qt = quottery_rpc_wrapper.QuotteryRpcWrapper('https://rpc.qubic.org', 'libs/quottery_cpp/lib/libquottery_cpp.so', 'DB_UPDATER')
+
+class TestQtryRpcWrapper(unittest.TestCase):
+
+    def test_get_qtry_basic_info(self):
+        sts, qtry_info = qt.get_qtry_basic_info()
+        self.assertEqual(sts, 0)
+        print(qtry_info)
+
+    def test_get_active_bets(self):
+        sts, active_bets = qt.get_active_bets()
+        self.assertEqual(sts, 0)
+        print(active_bets)
+
+    def test_get_bet_info(self):
+        sts, bet_info = qt.get_bet_info(53)
+        self.assertEqual(sts, 0)
+        print(bet_info)
+
+    def test_get_all_bets(self):
+        (sts, activeBets, tick_number) = qt.get_all_bets()
+        self.assertEqual(sts, 0)
+        print(tick_number)
+        print(activeBets)
+
+    def test_get_bet_option_detail(self):
+        (sts, bet_option_detail) = qt.get_bet_option_detail(52, 0)
+        self.assertEqual(sts, 0)
+        print(bet_option_detail)
+
+        (sts, bet_option_detail) = qt.get_bet_option_detail(52, 1)
+        self.assertEqual(sts, 0)
+        #print(bet_option_detail)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR will switch to use http endpoint for all request from node.
- Only the GetIdentityFromPubkey (K12 related function) still uses the qubic-cli wrapper.
- NodeIP will change to http-endpoint (https://rpc.qubic.org) or test one